### PR TITLE
ci: simplify error handling in ai-risks-analysis workflow

### DIFF
--- a/.github/workflows/ai-risks-analysis.yaml
+++ b/.github/workflows/ai-risks-analysis.yaml
@@ -133,10 +133,8 @@ jobs:
           
           # Pass prompt file to Gemini (read from stdin or file if supported)
           # If Gemini CLI doesn't support file input, we'll use the file content
-          set +e
           gemini "$(cat gemini_prompt.txt)" > gemini_output.txt 2>&1
           GEMINI_EXIT_CODE=$?
-          set -e
           
           echo "Gemini CLI exit code: $GEMINI_EXIT_CODE"
           

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/Customers/CustomersTests.cs
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/Customers/CustomersTests.cs
@@ -13,7 +13,6 @@ using Route4MeSDKLibrary.QueryTypes.V5.Customers;
 
 using Route4MeSdkV5UnitTest.V5;
 
-
 namespace Route4MeSDKUnitTest.V5
 {
     [TestFixture]

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/Orders/OrdersTests.cs
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/Orders/OrdersTests.cs
@@ -16,7 +16,6 @@ using Route4MeSDKLibrary.QueryTypes.V5.Orders;
 
 using Order = Route4MeSDK.DataTypes.Order;
 
-
 namespace Route4MeSdkV5UnitTest.V5.Orders
 {
     [TestFixture]


### PR DESCRIPTION
Remove unnecessary set +e/set -e commands around Gemini CLI execution, relying on default shell error handling behavior.