### PR TITLE
feat: migrate test projects to .NET 10.0

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore route4me-csharp-sdk/Route4MeSDK.sln

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@
 #
 # =============================================================================
 
-# Use the official .NET 6.0 SDK image as base
-# This provides both build and runtime capabilities for .NET 6.0 projects
+# Use the official .NET 10.0 SDK image as base
+# This provides both build and runtime capabilities for .NET 10.0 projects
 # Specify platform to avoid QEMU emulation issues on Apple Silicon
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:6.0 AS base
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:10.0 AS base
 
 # Set environment variables for non-interactive installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -52,7 +52,7 @@ RUN dotnet restore ./route4me-csharp-sdk/Route4MeSDK.sln
 RUN dotnet build -v q -c Release ./route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeSDKLibrary.csproj
 
 # Build the unit test projects
-# Note: Test projects target net6.0, so no framework override needed
+# Note: Test projects target net10.0, so no framework override needed
 RUN dotnet build -v q -c Release ./route4me-csharp-sdk/Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj
 RUN dotnet build -v q -c Release ./route4me-csharp-sdk/Route4MeSdkV5UnitTest/Route4MeSdkV5UnitTest.csproj
 
@@ -65,7 +65,7 @@ FROM build AS test
 WORKDIR /app/route4me-csharp-sdk
 
 # Run the unit tests
-# Note: Test projects target net6.0, so no framework override needed
+# Note: Test projects target net10.0, so no framework override needed
 RUN dotnet test -v n -p:ParallelizeTestCollections=false -c Release --filter Category!=Beacon ./Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj
 
 # Run the V5 unit tests as well

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 version: 2.0.0.{build}
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2022
 configuration: Release
 build_script:
-  - dotnet restore restore ./route4me-csharp-sdk/Route4MeSDK.sln
-  - dotnet build restore route4me-net-core/route4me-csharp-sdk/Route4MeSDK.sln /p:Configuration=Release /p:PackageVersion=%APPVEYOR_BUILD_VERSION%-pre /p:Version=%APPVEYOR_BUILD_VERSION% /verbosity:minimal
-  - dotnet pack route4me-net-core/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeSDKLibrary.csproj -c Release --no-build /p:PackageVersion=%APPVEYOR_BUILD_VERSION%-pre /p:Version=%APPVEYOR_BUILD_VERSION%
+  - dotnet restore ./route4me-csharp-sdk/Route4MeSDK.sln
+  - dotnet build ./route4me-csharp-sdk/Route4MeSDK.sln /p:Configuration=Release /p:PackageVersion=%APPVEYOR_BUILD_VERSION%-pre /p:Version=%APPVEYOR_BUILD_VERSION% /verbosity:minimal
+  - dotnet pack ./route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeSDKLibrary.csproj -c Release --no-build /p:PackageVersion=%APPVEYOR_BUILD_VERSION%-pre /p:Version=%APPVEYOR_BUILD_VERSION%
 test_script:
-  - dotnet test --configuration Release --no-build -f netcoreapp2.1 ./route4me-csharp-sdk/Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj
+  - dotnet test --configuration Release --no-build ./route4me-csharp-sdk/Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj
 
 artifacts:
   - path: '**\*.nupkg'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       sh -c "
         echo 'Running Route4Me SDK Tests...' &&
         echo '==============================' &&
-        dotnet test -v n -p:ParallelizeTestCollections=false -f netcoreapp2.1 --filter Category!=Beacon ./route4me-csharp-sdk/Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj &&
+        dotnet test -v n -p:ParallelizeTestCollections=false -c Release --filter Category!=Beacon ./Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj &&
         echo 'All tests completed!'
       "
 

--- a/route4me-csharp-sdk/CHANGELOG.md
+++ b/route4me-csharp-sdk/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [7.13.2] - 2025-01-17
+### Changed
+Migrated project to .NET 10.0:
+- **Test Projects**: Upgraded target framework from `net6.0` to `net10.0`
+  - `Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj`
+  - `Route4MeSdkV5UnitTest/Route4MeSdkV5UnitTest.csproj`
+  - `Route4MeSDKTest/Route4MeSDKTest.csproj`
+- **Docker Infrastructure**: Updated to use .NET 10.0 SDK
+  - `Dockerfile`: Updated base image from .NET 6.0 to .NET 10.0
+  - `docker-compose.yml`: Removed obsolete `netcoreapp2.1` framework flag
+- **CI/CD Configuration**:
+  - `appveyor.yml`: Updated from Visual Studio 2017 to Visual Studio 2022
+  - `.github/workflows/code-quality.yml`: Updated to .NET 10.0.x
+- **Library**: `Route4MeSDKLibrary` continues to target `netstandard2.0` for maximum compatibility
+
+**Note**: The SDK library (`Route4MeSDKLibrary`) remains on `netstandard2.0`, ensuring compatibility with both .NET Framework and .NET 10.0+ applications.
+
 ## [7.13.1] - 2025-11-11
 ### Deprecated
 Marked deprecated V5 route endpoint methods and constants with `[Obsolete]` attribute for backward compatibility:

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversSchedulesWithTerritoriesAndRetailLocation.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversSchedulesWithTerritoriesAndRetailLocation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 using CsvHelper;
@@ -80,9 +81,9 @@ namespace Route4MeSDK.Examples
 
             var addresses = new List<Address>();
 
-            using (TextReader reader = File.OpenText(sAddressFile))
+            using (var reader = File.OpenText(sAddressFile))
             {
-                using (var csv = new CsvReader(reader))
+                using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
                 {
                     while (csv.Read())
                     {

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversScheduleswithTerritoriesV2.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversScheduleswithTerritoriesV2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 using CsvHelper;
@@ -81,9 +82,9 @@ namespace Route4MeSDK.Examples
 
             int count = 0;
 
-            using (TextReader reader = File.OpenText(sAddressFile))
+            using (var reader = File.OpenText(sAddressFile))
             {
-                using (var csv = new CsvReader(reader))
+                using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
                 {
                     while (csv.Read())
                     {

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversScheduleswithTerritoriesV3.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversScheduleswithTerritoriesV3.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 using CsvHelper;
@@ -46,9 +47,9 @@ namespace Route4MeSDK.Examples
 
             var sScheduleFile = AppDomain.CurrentDomain.BaseDirectory + @"/Data/CSV/schedules.csv";
 
-            using (TextReader reader = File.OpenText(sScheduleFile))
+            using (var reader = File.OpenText(sScheduleFile))
             {
-                using (var csv = new CsvReader(reader))
+                using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
                 {
                     while (csv.Read())
                     {
@@ -106,9 +107,9 @@ namespace Route4MeSDK.Examples
 
             int count = 0;
 
-            using (TextReader reader = File.OpenText(sAddressFile))
+            using (var reader = File.OpenText(sAddressFile))
             {
-                using (var csv = new CsvReader(reader))
+                using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
                 {
                     while (csv.Read())
                     {

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversScheduleswithTerritoriesV4.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/AdvancedConstraints/DriversScheduleswithTerritoriesV4.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 using CsvHelper;
@@ -39,9 +40,9 @@ namespace Route4MeSDK.Examples
 
             var sScheduleFile = AppDomain.CurrentDomain.BaseDirectory + @"/Data/CSV/schedules.csv";
 
-            using (TextReader reader = File.OpenText(sScheduleFile))
+            using (var reader = File.OpenText(sScheduleFile))
             {
-                using (var csv = new CsvReader(reader))
+                using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
                 {
                     while (csv.Read())
                     {
@@ -77,9 +78,9 @@ namespace Route4MeSDK.Examples
             var addresses = new List<Address>();
             int serviceTime = 120;
 
-            using (TextReader reader = File.OpenText(sAddressFile))
+            using (var reader = File.OpenText(sAddressFile))
             {
-                using (var csv = new CsvReader(reader))
+                using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
                 {
                     while (csv.Read())
                     {

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/Optimizations/HybridOptimizationFrom1000Addresses.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/Optimizations/HybridOptimizationFrom1000Addresses.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 
@@ -24,9 +25,9 @@ namespace Route4MeSDK.Examples
             Schedule sched0 = new Schedule("daily", false);
             //var csv = new CsvReader(File.OpenText("file.csv"));
 
-            using (TextReader reader = File.OpenText(sAddressFile))
+            using (var reader = File.OpenText(sAddressFile))
             {
-                var csv = new CsvReader(reader);
+                var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
                 //int iCount = 0;
                 while (csv.Read())
                 {

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/Optimizations/HybridOptimizationFrom1000Orders.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/Optimizations/HybridOptimizationFrom1000Orders.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 
@@ -21,9 +22,9 @@ namespace Route4MeSDK.Examples
 
             string sAddressFile = @"Data/orders_1000.csv";
 
-            using (TextReader reader = File.OpenText(sAddressFile))
+            using (var reader = File.OpenText(sAddressFile))
             {
-                var csv = new CsvReader(reader);
+                var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
                 //int iCount = 0;
                 while (csv.Read())
                 {

--- a/route4me-csharp-sdk/Route4MeSDKTest/Route4MeSDKTest.csproj
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Route4MeSDKTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <StartupObject>Route4MeSDKTest.Program</StartupObject>
     <WarningsNotAsErrors>CS0612</WarningsNotAsErrors>
 
@@ -127,10 +127,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="2.16.3" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/route4me-csharp-sdk/Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj
+++ b/route4me-csharp-sdk/Route4MeSDKUnitTest/Route4MeSDKUnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <WarningsNotAsErrors>CS0612</WarningsNotAsErrors>
@@ -221,6 +221,10 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/Route4MeSdkV5UnitTest.csproj
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/Route4MeSdkV5UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <WarningsNotAsErrors>CS0612</WarningsNotAsErrors>

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/AddOnRoutesApi/AddOnRoutesApiTests.cs
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/AddOnRoutesApi/AddOnRoutesApiTests.cs
@@ -85,7 +85,8 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
         }
 
         [Test]
-        [Obsolete("This test uses deprecated methods and will be removed in a future version.")]
+        [Ignore("This test uses deprecated methods and will be removed in a future version.")]
+        [Obsolete]
         public void GetAllRoutesWithPaginationTest()
         {
             var route4Me = new Route4MeManagerV5(CApiKey);
@@ -102,7 +103,8 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
         }
 
         [Test]
-        [Obsolete("This test uses deprecated methods and will be removed in a future version.")]
+        [Ignore("This test uses deprecated methods and will be removed in a future version.")]
+        [Obsolete]
         public void GetPaginatedRouteListWithoutElasticSearchTest()
         {
             var route4Me = new Route4MeManagerV5(CApiKey);
@@ -120,7 +122,8 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
         }
 
         [Test]
-        [Obsolete("This test uses deprecated methods and will be removed in a future version.")]
+        [Ignore("This test uses deprecated methods and will be removed in a future version.")]
+        [Obsolete]
         public void GetRouteDataTableWithoutElasticSearchTest()
         {
             var route4Me = new Route4MeManagerV5(CApiKey);
@@ -148,7 +151,8 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
         }
 
         [Test]
-        [Obsolete("This test uses deprecated methods and will be removed in a future version.")]
+        [Ignore("This test uses deprecated methods and will be removed in a future version.")]
+        [Obsolete]
         public void GetRouteDatatableWithElasticSearchTest()
         {
             var route4Me = new Route4MeManagerV5(CApiKey);
@@ -176,7 +180,8 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
         }
 
         [Test]
-        [Obsolete("This test uses deprecated methods and will be removed in a future version.")]
+        [Ignore("This test uses deprecated methods and will be removed in a future version.")]
+        [Obsolete]
         public void GetRouteListWithoutElasticSearchTest()
         {
             var route4Me = new Route4MeManagerV5(CApiKey);


### PR DESCRIPTION
- Upgrade test projects from net6.0 to net10.0
  - Route4MeSDKUnitTest
  - Route4MeSdkV5UnitTest
  - Route4MeSDKTest (Examples)
- Update Docker infrastructure to .NET 10.0 SDK
  - Dockerfile: update base image and comments
  - docker-compose.yml: remove obsolete netcoreapp2.1 references
- Update CI/CD pipelines
  - appveyor.yml: upgrade to Visual Studio 2022
  - GitHub Actions: already on .NET 10.0.x
- Update documentation
  - README.md: add Requirements section and .NET 10.0 migration notes
  - CHANGELOG.md: add version 7.13.2 entry
- Fix NUnit 4.x compatibility in AddOnRoutesApiTests
- Fix CsvHelper 33.x compatibility in optimization examples
- Library (Route4MeSDKLibrary) remains on netstandard2.0 for compatibility