### PR TITLE
feat!: add configurable HTTP client timeout

### DIFF
--- a/route4me-csharp-sdk/CHANGELOG.md
+++ b/route4me-csharp-sdk/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [7.13.3] - 2025-12-17
+### Changed
+- Reduced default HTTP request timeout from 30 minutes to 30 seconds
+- Added configurable HTTP timeout via `Route4MeConfig.HttpTimeout` property
+- Users can now customize timeout globally before making API calls
+
 ## [7.13.2] - 2025-01-17
 ### Changed
 Migrated project to .NET 10.0:

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/HttpClientHolderManager.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/HttpClientHolderManager.cs
@@ -18,6 +18,12 @@ namespace Route4MeSDKLibrary
 
         private static readonly object SyncRoot = new object();
 
+        /// <summary>
+        ///     Gets or sets the HTTP request timeout. Default is 30 seconds.
+        ///     Change this value to configure the timeout for all HTTP requests made by the SDK.
+        /// </summary>
+        public static TimeSpan RequestsTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
         static HttpClientHolderManager()
         {
             // ReSharper disable once ObjectCreationAsStatement
@@ -59,7 +65,7 @@ namespace Route4MeSDKLibrary
 
         private static HttpClient CreateHttpClient(string baseAddress, string apiKey = null)
         {
-            var result = new HttpClient { BaseAddress = new Uri(baseAddress), Timeout = TimeSpan.FromMinutes(30) };
+            var result = new HttpClient { BaseAddress = new Uri(baseAddress), Timeout = RequestsTimeout };
 
             result.DefaultRequestHeaders.Accept.Clear();
             result.DefaultRequestHeaders.ConnectionClose = false;

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeConfig.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeConfig.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Route4MeSDKLibrary
+{
+    /// <summary>
+    ///     Global configuration settings for the Route4Me SDK.
+    /// </summary>
+    public static class Route4MeConfig
+    {
+        /// <summary>
+        ///     Gets or sets the HTTP request timeout for all API calls made by the SDK.
+        ///     Default is 30 seconds. Set this value before making any API calls to configure the timeout globally.
+        /// </summary>
+        /// <example>
+        ///     // Set a 60-second timeout for all API calls
+        ///     Route4MeConfig.HttpTimeout = TimeSpan.FromSeconds(60);
+        ///
+        ///     // Or use minutes
+        ///     Route4MeConfig.HttpTimeout = TimeSpan.FromMinutes(2);
+        /// </example>
+        public static TimeSpan HttpTimeout
+        {
+            get => HttpClientHolderManager.RequestsTimeout;
+            set => HttpClientHolderManager.RequestsTimeout = value;
+        }
+    }
+}

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/ConfigurationExample.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/ConfigurationExample.cs
@@ -1,0 +1,42 @@
+using System;
+
+using Route4MeSDKLibrary;
+
+namespace Route4MeSDK.Examples
+{
+    /// <summary>
+    ///     Example demonstrating how to configure the Route4Me SDK globally.
+    /// </summary>
+    public sealed partial class Route4MeExamples
+    {
+        public void TimeoutConfigurationExample()
+        {
+            Console.WriteLine("=== Route4Me SDK Configuration Examples ===\n");
+
+            // Example 1: Check default timeout
+            Console.WriteLine($"Default HTTP timeout: {Route4MeConfig.HttpTimeout.TotalSeconds} seconds");
+
+            // Example 2: Set a custom timeout (60 seconds)
+            Console.WriteLine("\nSetting custom timeout to 60 seconds...");
+            Route4MeConfig.HttpTimeout = TimeSpan.FromSeconds(60);
+            Console.WriteLine($"New HTTP timeout: {Route4MeConfig.HttpTimeout.TotalSeconds} seconds");
+
+            // Example 3: Set timeout using minutes
+            Console.WriteLine("\nSetting timeout to 2 minutes...");
+            Route4MeConfig.HttpTimeout = TimeSpan.FromMinutes(2);
+            Console.WriteLine($"New HTTP timeout: {Route4MeConfig.HttpTimeout.TotalMinutes} minutes");
+
+            // Example 4: Reset to default (30 seconds)
+            Console.WriteLine("\nResetting to default timeout (30 seconds)...");
+            Route4MeConfig.HttpTimeout = TimeSpan.FromSeconds(30);
+            Console.WriteLine($"HTTP timeout: {Route4MeConfig.HttpTimeout.TotalSeconds} seconds");
+
+            Console.WriteLine("\n=== Important Notes ===");
+            Console.WriteLine("- Set the timeout BEFORE making any API calls");
+            Console.WriteLine("- The timeout applies to all subsequent HTTP requests");
+            Console.WriteLine("- Default timeout is 30 seconds");
+            Console.WriteLine("- Increase for long-running operations (e.g., large optimizations)");
+            Console.WriteLine("- Decrease for faster failure detection in time-sensitive scenarios");
+        }
+    }
+}

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/ConfigurationTests.cs
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/ConfigurationTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using Route4MeSDKLibrary;
+
+namespace Route4MeSdkV5UnitTest.V5
+{
+    [TestFixture]
+    public class ConfigurationTests
+    {
+        [Test]
+        public void HttpClient_UsesConfiguredTimeout_WhenCreated()
+        {
+            // Arrange
+            var originalTimeout = Route4MeConfig.HttpTimeout;
+            var customTimeout = TimeSpan.FromSeconds(45);
+
+            try
+            {
+                // Set custom timeout before creating HttpClient
+                Route4MeConfig.HttpTimeout = customTimeout;
+
+                // Use a unique base address to ensure we get a fresh HttpClient instance
+                var uniqueBaseAddress = $"https://test-{Guid.NewGuid()}.route4me.com";
+
+                // Act - Use reflection to access the internal HttpClientHolderManager
+                var holderManagerType = Type.GetType("Route4MeSDKLibrary.HttpClientHolderManager, Route4MeSDKLibrary");
+                Assert.IsNotNull(holderManagerType, "HttpClientHolderManager type not found");
+
+                var acquireMethod = holderManagerType.GetMethod("AcquireHttpClientHolder",
+                    BindingFlags.Public | BindingFlags.Static);
+                Assert.IsNotNull(acquireMethod, "AcquireHttpClientHolder method not found");
+
+                var holder = acquireMethod.Invoke(null, new object[] { uniqueBaseAddress, null });
+                Assert.IsNotNull(holder, "HttpClientHolder should not be null");
+
+                // Get the HttpClient from the holder
+                var httpClientProperty = holder.GetType().GetProperty("HttpClient");
+                Assert.IsNotNull(httpClientProperty, "HttpClient property not found");
+
+                var httpClient = httpClientProperty.GetValue(holder) as System.Net.Http.HttpClient;
+                Assert.IsNotNull(httpClient, "HttpClient should not be null");
+
+                // Assert - Verify the HttpClient has the custom timeout
+                Assert.AreEqual(customTimeout, httpClient.Timeout,
+                    $"HttpClient timeout should be {customTimeout.TotalSeconds} seconds");
+
+                // Cleanup - Release the holder
+                var releaseMethod = holderManagerType.GetMethod("ReleaseHttpClientHolder",
+                    BindingFlags.Public | BindingFlags.Static);
+                releaseMethod?.Invoke(null, new object[] { uniqueBaseAddress });
+            }
+            finally
+            {
+                // Restore original timeout
+                Route4MeConfig.HttpTimeout = originalTimeout;
+            }
+        }
+
+        [Test]
+        public void HttpClient_DefaultTimeout_Is30Seconds_WhenNoConfigurationSet()
+        {
+            // Arrange
+            var originalTimeout = Route4MeConfig.HttpTimeout;
+
+            try
+            {
+                // Reset to default
+                Route4MeConfig.HttpTimeout = TimeSpan.FromSeconds(30);
+
+                // Use a unique base address to ensure we get a fresh HttpClient instance
+                var uniqueBaseAddress = $"https://test-default-{Guid.NewGuid()}.route4me.com";
+
+                // Act - Use reflection to access the internal HttpClientHolderManager
+                var holderManagerType = Type.GetType("Route4MeSDKLibrary.HttpClientHolderManager, Route4MeSDKLibrary");
+                var acquireMethod = holderManagerType.GetMethod("AcquireHttpClientHolder",
+                    BindingFlags.Public | BindingFlags.Static);
+                var holder = acquireMethod.Invoke(null, new object[] { uniqueBaseAddress, null });
+                var httpClientProperty = holder.GetType().GetProperty("HttpClient");
+                var httpClient = httpClientProperty.GetValue(holder) as System.Net.Http.HttpClient;
+
+                // Assert - Verify the HttpClient has the default 30-second timeout
+                Assert.AreEqual(TimeSpan.FromSeconds(30), httpClient.Timeout,
+                    "HttpClient should have default 30-second timeout");
+
+                // Cleanup
+                var releaseMethod = holderManagerType.GetMethod("ReleaseHttpClientHolder",
+                    BindingFlags.Public | BindingFlags.Static);
+                releaseMethod?.Invoke(null, new object[] { uniqueBaseAddress });
+            }
+            finally
+            {
+                // Restore original timeout
+                Route4MeConfig.HttpTimeout = originalTimeout;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Route4MeConfig.HttpTimeout property to allow global configuration of HTTP request timeout for all SDK API calls. Default timeout reduced from 30 minutes to 30 seconds for better reliability.

- Add Route4MeConfig static class for global SDK settings
- Add HttpTimeout property with default of 30 seconds
- Add ConfigurationExample demonstrating timeout configuration
- Add ConfigurationTests validating timeout behavior
- Update CHANGELOG.md with version 7.13.3 changes

BREAKING CHANGE: Default HTTP timeout reduced from 30 minutes to 30 seconds.