### PR TITLE
feat(route-api): add timezone and compress_path_points query parameters

### DIFF
--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/RouteParameters.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/RouteParameters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/RouteParameters.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/RouteParameters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/OptimizationParameters.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/OptimizationParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 using Route4MeSDK.DataTypes;
 

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/RouteParametersQuery.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/RouteParametersQuery.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 using Route4MeSDK.DataTypes;
 
@@ -88,6 +88,30 @@ namespace Route4MeSDK.QueryTypes
         [IgnoreDataMember]
         [HttpQueryMemberAttribute(Name = "end_date", EmitDefaultValue = false)]
         public string EndDate { get; set; }
+
+        /// <summary>
+        ///     Boolean flag that tells API to use timezone column.
+        ///     <para>Available values: </para>
+        ///     <value>true/1 - use timezone parameter. false/0 - do not use timezone parameter.</value>
+        ///     <remarks>
+        ///         <para>Query parameter. When set to true, will be serialized as "1" in the query string.</para>
+        ///         <para>This parameter works together with the <see cref="Timezone"/> parameter.</para>
+        ///     </remarks>
+        /// </summary>
+        [IgnoreDataMember]
+        [HttpQueryMemberAttribute(Name = "use_timezone", EmitDefaultValue = false)]
+        public bool? UseTimezone { get; set; }
+
+        /// <summary>
+        ///     String which defines timezone (e.g., "Australia/Melbourne").
+        ///     <remarks>
+        ///         <para>Query parameter. Used when <see cref="UseTimezone"/> is set to true.</para>
+        ///         <para>Example values: "America/New_York", "Europe/London", "Australia/Melbourne"</para>
+        ///     </remarks>
+        /// </summary>
+        [IgnoreDataMember]
+        [HttpQueryMemberAttribute(Name = "timezone", EmitDefaultValue = false)]
+        public string Timezone { get; set; }
 
         /// <summary>
         ///     Output addresses and directions in the original optimization request sequence.
@@ -265,6 +289,16 @@ namespace Route4MeSDK.QueryTypes
         ///     If true, the route time is shifted by timezone.
         /// </summary>
         public bool ShiftByTimeZone { get; set; }
+
+        /// <summary>
+        ///     If equal to 1, path points are compressed in route response.
+        ///     <remarks>
+        ///         <para>Query parameter. When set to true, will be serialized as "1" in the query string.</para>
+        ///     </remarks>
+        /// </summary>
+        [IgnoreDataMember]
+        [HttpQueryMemberAttribute(Name = "compress_path_points", EmitDefaultValue = false)]
+        public bool? CompressPathPoints { get; set; }
 
         /// <summary>
         ///     An array of the route IDs to duplicate.

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/V5/OptimizationParameters.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/V5/OptimizationParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 using Route4MeSDK.DataTypes.V5;
 

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/V5/RouteParametersQuery.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/V5/RouteParametersQuery.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 using Route4MeSDK.DataTypes.V5;
 
@@ -67,6 +67,30 @@ namespace Route4MeSDK.QueryTypes.V5
         [IgnoreDataMember]
         [HttpQueryMemberAttribute(Name = "end_date", EmitDefaultValue = false)]
         public string EndDate { get; set; }
+
+        /// <summary>
+        ///     Boolean flag that tells API to use timezone column.
+        ///     <para>Available values: </para>
+        ///     <value>true/1 - use timezone parameter. false/0 - do not use timezone parameter.</value>
+        ///     <remarks>
+        ///         <para>Query parameter. When set to true, will be serialized as "1" in the query string.</para>
+        ///         <para>This parameter works together with the <see cref="Timezone"/> parameter.</para>
+        ///     </remarks>
+        /// </summary>
+        [IgnoreDataMember]
+        [HttpQueryMemberAttribute(Name = "use_timezone", EmitDefaultValue = false)]
+        public bool? UseTimezone { get; set; }
+
+        /// <summary>
+        ///     String which defines timezone (e.g., "Australia/Melbourne").
+        ///     <remarks>
+        ///         <para>Query parameter. Used when <see cref="UseTimezone"/> is set to true.</para>
+        ///         <para>Example values: "America/New_York", "Europe/London", "Australia/Melbourne"</para>
+        ///     </remarks>
+        /// </summary>
+        [IgnoreDataMember]
+        [HttpQueryMemberAttribute(Name = "timezone", EmitDefaultValue = false)]
+        public string Timezone { get; set; }
 
         /// <summary>
         ///     Output addresses and directions in the original optimization request sequence.
@@ -168,6 +192,16 @@ namespace Route4MeSDK.QueryTypes.V5
         [IgnoreDataMember]
         [HttpQueryMemberAttribute(Name = "bundling_items", EmitDefaultValue = false)]
         public bool? BundlingItems { get; set; }
+
+        /// <summary>
+        ///     If equal to 1, path points are compressed in route response.
+        ///     <remarks>
+        ///         <para>Query parameter. When set to true, will be serialized as "1" in the query string.</para>
+        ///     </remarks>
+        /// </summary>
+        [IgnoreDataMember]
+        [HttpQueryMemberAttribute(Name = "compress_path_points", EmitDefaultValue = false)]
+        public bool? CompressPathPoints { get; set; }
 
         [IgnoreDataMember]
         [HttpQueryMemberAttribute(Name = "page", EmitDefaultValue = false)]


### PR DESCRIPTION
Add support for timezone-related query parameters to route.php GET endpoint:
- Add UseTimezone (bool?) query parameter to RouteParametersQuery (V4 and V5)
- Add Timezone (string) query parameter to RouteParametersQuery (V4 and V5)
- Add CompressPathPoints (bool?) query parameter to RouteParametersQuery (V4 and V5)

These parameters align with Route API V4 Swagger specification for the /route.php GET endpoint. Boolean values serialize to '1' or '0' as per existing SDK conventions.

Parameters are properly documented with XML comments including:
- Available values and serialization behavior
- Cross-references between related parameters
- Example timezone values