### PR TITLE
feat(routes): add V5 routes list endpoint and route list data fields

### DIFF
--- a/route4me-csharp-sdk/CHANGELOG.md
+++ b/route4me-csharp-sdk/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+git ## [v8.10.0] - 2026-02-02
+### Added
+- Routes API V5: Routes List endpoint (POST /api/v5.0/routes/list)
+  - New constant `R4MEInfrastructureSettingsV5.RoutesList`
+  - `RouteManagerV5.GetRoutesList` / `GetRoutesListAsync`
+  - `Route4MeManagerV5.GetRoutesList` / `GetRoutesListAsync`
+- Routes API V5: additional route list data items on `DataObjectRoute` for list responses (RouteScoutResource alignment)
+  - `RouteScheduledStartUnix`, `ActualStartTimestamp`, `ActualRouteDuration`
+  - `PlannedTotalServiceTime`, `GeofenceActualTotalServiceTime`, `ManualRegisteredActualTotalServiceTime`
+  - `PlannedTotalTravelTime`, `TelematicsActualTravelTimestamp`, `MobileActualTravelTimestamp`
+  - `TelematicsActualTravelDistance`, `MobileActualTravelDistance`
+
 ## [v8.9.0] - 2026-01-22
 ### Added
 - Route API: add `use_combined_timestamp` query parameter support for V4 and V5 APIs

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Consts.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Consts.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Route4MeSDK
 {
@@ -101,6 +101,7 @@ namespace Route4MeSDK
         public const string MainHostWeb = "https://wh.route4me.com/modules/webapi/v5.0";
 
         public const string Routes = MainHost + "/routes";
+        public const string RoutesList = MainHost + "/routes/list";
         public const string Routes51 = MainHost51 + "/routes";
 
         public const string RoutesDuplicate = MainHost + "/routes/duplicate";

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/Route.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/Route.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -221,6 +221,83 @@ namespace Route4MeSDK.DataTypes.V5
         [DataMember(Name = "actual_travel_time", EmitDefaultValue = false)]
         [ReadOnly(true)]
         public long? ActualTravelTime { get; set; }
+
+        /// <summary>
+        ///     Route scheduled start time (Unix timestamp).
+        /// </summary>
+        [DataMember(Name = "route_scheduled_start_unix", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? RouteScheduledStartUnix { get; set; }
+
+        /// <summary>
+        ///     Actual start time (Unix timestamp).
+        /// </summary>
+        [DataMember(Name = "actual_start_timestamp", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? ActualStartTimestamp { get; set; }
+
+        /// <summary>
+        ///     Actual route duration (seconds).
+        /// </summary>
+        [DataMember(Name = "actual_route_duration", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? ActualRouteDuration { get; set; }
+
+        /// <summary>
+        ///     Planned total service time (seconds).
+        /// </summary>
+        [DataMember(Name = "planned_total_service_time", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? PlannedTotalServiceTime { get; set; }
+
+        /// <summary>
+        ///     Geofence-detected actual total service time (seconds).
+        /// </summary>
+        [DataMember(Name = "geofence_actual_total_service_time", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? GeofenceActualTotalServiceTime { get; set; }
+
+        /// <summary>
+        ///     Manual registered actual total service time (seconds).
+        /// </summary>
+        [DataMember(Name = "manual_registered_actual_total_service_time", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? ManualRegisteredActualTotalServiceTime { get; set; }
+
+        /// <summary>
+        ///     Planned total travel time (seconds).
+        /// </summary>
+        [DataMember(Name = "planned_total_travel_time", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? PlannedTotalTravelTime { get; set; }
+
+        /// <summary>
+        ///     Telematics actual travel timestamp (Unix timestamp).
+        /// </summary>
+        [DataMember(Name = "telematics_actual_travel_timestamp", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? TelematicsActualTravelTimestamp { get; set; }
+
+        /// <summary>
+        ///     Mobile actual travel timestamp (Unix timestamp).
+        /// </summary>
+        [DataMember(Name = "mobile_actual_travel_timestamp", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public long? MobileActualTravelTimestamp { get; set; }
+
+        /// <summary>
+        ///     Telematics actual travel distance.
+        /// </summary>
+        [DataMember(Name = "telematics_actual_travel_distance", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public double? TelematicsActualTravelDistance { get; set; }
+
+        /// <summary>
+        ///     Mobile actual travel distance.
+        /// </summary>
+        [DataMember(Name = "mobile_actual_travel_distance", EmitDefaultValue = false)]
+        [ReadOnly(true)]
+        public double? MobileActualTravelDistance { get; set; }
 
         /// <summary>
         ///     Actual footsteps.

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Managers/RouteManagerV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Managers/RouteManagerV5.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -54,6 +54,39 @@ namespace Route4MeSDKLibrary.Managers
         {
             var result = await GetJsonObjectFromAPIAsync<DataObjectRoute[]>(routeParameters,
                 R4MEInfrastructureSettingsV5.Routes,
+                HttpMethodType.Post,
+                null, true, false).ConfigureAwait(false);
+
+            return new Tuple<DataObjectRoute[], ResultResponse>(result.Item1, result.Item2);
+        }
+
+        /// <summary>
+        /// Retrieves a list of the routes via the routes/list endpoint (POST /api/v5.0/routes/list).
+        /// </summary>
+        /// <param name="routeParameters">Query parameters</param>
+        /// <param name="resultResponse">Failure response</param>
+        /// <returns>An array of the routes</returns>
+        public DataObjectRoute[] GetRoutesList(RouteParametersQuery routeParameters, out ResultResponse resultResponse)
+        {
+            var result = GetJsonObjectFromAPI<DataObjectRoute[]>(routeParameters,
+                R4MEInfrastructureSettingsV5.RoutesList,
+                HttpMethodType.Post,
+                false,
+                true,
+                out resultResponse);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieves a list of the routes via the routes/list endpoint asynchronously (POST /api/v5.0/routes/list).
+        /// </summary>
+        /// <param name="routeParameters">Query parameters <see cref="RouteParametersQuery"/></param>
+        /// <returns>A Tuple type object containing a route list or/and failure response</returns>
+        public async Task<Tuple<DataObjectRoute[], ResultResponse>> GetRoutesListAsync(RouteParametersQuery routeParameters)
+        {
+            var result = await GetJsonObjectFromAPIAsync<DataObjectRoute[]>(routeParameters,
+                R4MEInfrastructureSettingsV5.RoutesList,
                 HttpMethodType.Post,
                 null, true, false).ConfigureAwait(false);
 

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeManagerV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeManagerV5.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using Route4MeSDK.DataTypes.V5;
@@ -928,6 +928,27 @@ namespace Route4MeSDK
         public Task<Tuple<DataObjectRoute[], ResultResponse>> GetRoutesAsync(RouteParametersQuery routeParameters)
         {
             return _routeManager.GetRoutesAsync(routeParameters);
+        }
+
+        /// <summary>
+        /// Retrieves a list of the routes via the routes/list endpoint (POST /api/v5.0/routes/list).
+        /// </summary>
+        /// <param name="routeParameters">Query parameters</param>
+        /// <param name="resultResponse">Failure response</param>
+        /// <returns>An array of the routes</returns>
+        public DataObjectRoute[] GetRoutesList(RouteParametersQuery routeParameters, out ResultResponse resultResponse)
+        {
+            return _routeManager.GetRoutesList(routeParameters, out resultResponse);
+        }
+
+        /// <summary>
+        /// Retrieves a list of the routes via the routes/list endpoint asynchronously (POST /api/v5.0/routes/list).
+        /// </summary>
+        /// <param name="routeParameters">Query parameters <see cref="RouteParametersQuery"/></param>
+        /// <returns>A Tuple type object containing a route list or/and failure response</returns>
+        public Task<Tuple<DataObjectRoute[], ResultResponse>> GetRoutesListAsync(RouteParametersQuery routeParameters)
+        {
+            return _routeManager.GetRoutesListAsync(routeParameters);
         }
 
         /// <summary>

--- a/scripts/check-code-quality.sh
+++ b/scripts/check-code-quality.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run format check and build with analyzers (matches .github/workflows/code-quality.yml).
+# Requires: dotnet SDK (e.g. .NET 10.0.x)
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SLN="$ROOT/route4me-csharp-sdk/Route4MeSDK.sln"
+
+echo "Restoring..."
+dotnet restore "$SLN"
+
+echo "Checking code formatting (no changes applied)..."
+dotnet format "$SLN" --verify-no-changes --verbosity diagnostic
+
+echo "Building with analyzers (warnings as errors)..."
+dotnet build "$SLN" --configuration Release --no-restore /p:TreatWarningsAsErrors=true
+
+echo "Code quality checks passed."


### PR DESCRIPTION
- Add RoutesList constant and GetRoutesList/GetRoutesListAsync (POST /api/v5.0/routes/list)
- Add 12 route list properties to DataObjectRoute: RouteScheduledStartUnix, ActualStartTimestamp, ActualRouteDuration, PlannedTotalServiceTime, GeofenceActualTotalServiceTime, ManualRegisteredActualTotalServiceTime, PlannedTotalTravelTime, TelematicsActualTravelTimestamp, MobileActualTravelTimestamp, TelematicsActualTravelDistance, MobileActualTravelDistance
- Bump CHANGELOG to v8.10.0 (2026-02-02)
- Add scripts/check-code-quality.sh for format and analyzer checks