### PR TITLE
feat(routes): add route_custom_data get/set for V5 API

### DIFF
--- a/route4me-csharp-sdk/CHANGELOG.md
+++ b/route4me-csharp-sdk/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [v8.12.0] - 2026-02-16
+### Added
+- Routes API V5: `route_custom_data` support for route-level custom key/value data
+  - New `RouteCustomData` property on `DataObjectRoute` (response model)
+  - New `RouteCustomData` property on `RouteFilterResponseData` (list/filter response model)
+  - New `RouteCustomData` property on `RouteParametersQuery` (V5) for route update requests
+  - `RouteManagerV5.GetRouteCustomData` / `GetRouteCustomDataAsync` — retrieve route custom data by route ID
+  - `RouteManagerV5.UpdateRouteCustomData` / `UpdateRouteCustomDataAsync` — update route custom data by route ID
+  - `Route4MeManagerV5.GetRouteCustomData` / `GetRouteCustomDataAsync`
+  - `Route4MeManagerV5.UpdateRouteCustomData` / `UpdateRouteCustomDataAsync`
+
 ## [v8.11.0] - 2026-02-05
 ### Added
 - Routes API V5: Get Route endpoint (GET /api/v5.0/routes/{route_id})

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/Route.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/Route.cs
@@ -431,5 +431,11 @@ namespace Route4MeSDK.DataTypes.V5
         /// </summary>
         [DataMember(Name = "facility_ids", EmitDefaultValue = false)]
         public string[] FacilityIds { get; set; }
+
+        /// <summary>
+        ///     Route-level custom data as an array of key-value dictionaries.
+        /// </summary>
+        [DataMember(Name = "route_custom_data", EmitDefaultValue = false)]
+        public Dictionary<string, string>[] RouteCustomData { get; set; }
     }
 }

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/RouteFilterResponse.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/Routes/RouteFilterResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Route4MeSDK.DataTypes.V5
 {
@@ -253,5 +254,11 @@ namespace Route4MeSDK.DataTypes.V5
         /// </summary>
         [DataMember(Name = "facility_ids", EmitDefaultValue = false)]
         public string[] FacilityIds { get; set; }
+
+        /// <summary>
+        ///     Route-level custom data as an array of key-value dictionaries.
+        /// </summary>
+        [DataMember(Name = "route_custom_data", EmitDefaultValue = false)]
+        public Dictionary<string, string>[] RouteCustomData { get; set; }
     }
 }

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Managers/RouteManagerV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Managers/RouteManagerV5.cs
@@ -568,5 +568,76 @@ namespace Route4MeSDKLibrary.Managers
                 false,
                 false);
         }
+
+        /// <summary>
+        /// Gets the route-level custom data for the specified route.
+        /// Uses GET /api/v5.0/routes/{route_id} and extracts the route_custom_data field.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <param name="resultResponse">Failure response</param>
+        /// <returns>An array of dictionaries representing route custom data, or null if not set</returns>
+        public Dictionary<string, string>[] GetRouteCustomData(string routeId, out ResultResponse resultResponse)
+        {
+            var response = GetRoute(routeId, out resultResponse);
+
+            return response?.Data?.RouteCustomData;
+        }
+
+        /// <summary>
+        /// Gets the route-level custom data for the specified route asynchronously.
+        /// Uses GET /api/v5.0/routes/{route_id} and extracts the route_custom_data field.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <returns>A Tuple containing route custom data or/and failure response</returns>
+        public async Task<Tuple<Dictionary<string, string>[], ResultResponse>> GetRouteCustomDataAsync(string routeId)
+        {
+            var result = await GetRouteAsync(routeId).ConfigureAwait(false);
+
+            return new Tuple<Dictionary<string, string>[], ResultResponse>(
+                result.Item1?.Data?.RouteCustomData,
+                result.Item2);
+        }
+
+        /// <summary>
+        /// Updates route-level custom data for the specified route.
+        /// Uses PUT /api/v5.0/routes with route_custom_data in the request body.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <param name="customData">The custom data to set on the route</param>
+        /// <param name="resultResponse">Failure response</param>
+        /// <returns>The updated route object</returns>
+        public DataObjectRoute UpdateRouteCustomData(
+            string routeId,
+            Dictionary<string, string>[] customData,
+            out ResultResponse resultResponse)
+        {
+            var routeQuery = new RouteParametersQuery
+            {
+                RouteId = routeId,
+                RouteCustomData = customData
+            };
+
+            return UpdateRoute(routeQuery, out resultResponse);
+        }
+
+        /// <summary>
+        /// Updates route-level custom data for the specified route asynchronously.
+        /// Uses PUT /api/v5.0/routes with route_custom_data in the request body.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <param name="customData">The custom data to set on the route</param>
+        /// <returns>A Tuple containing the updated route or/and failure response</returns>
+        public Task<Tuple<DataObjectRoute, ResultResponse, string>> UpdateRouteCustomDataAsync(
+            string routeId,
+            Dictionary<string, string>[] customData)
+        {
+            var routeQuery = new RouteParametersQuery
+            {
+                RouteId = routeId,
+                RouteCustomData = customData
+            };
+
+            return UpdateRouteAsync(routeQuery);
+        }
     }
 }

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/V5/RouteParametersQuery.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/QueryTypes/V5/RouteParametersQuery.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 using Route4MeSDK.DataTypes.V5;
@@ -256,5 +257,12 @@ namespace Route4MeSDK.QueryTypes.V5
         /// </summary>
         [DataMember(Name = "unlink_from_master_optimization", EmitDefaultValue = false)]
         public bool UnlinkFromMasterOptimization { get; set; }
+
+        /// <summary>
+        ///     Route-level custom data as an array of key-value dictionaries.
+        ///     Used when updating a route to set or replace route custom data.
+        /// </summary>
+        [DataMember(Name = "route_custom_data", EmitDefaultValue = false)]
+        public Dictionary<string, string>[] RouteCustomData { get; set; }
     }
 }

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeManagerV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeManagerV5.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Route4MeSDK.DataTypes.V5;
@@ -1214,6 +1215,59 @@ namespace Route4MeSDK
                                                 DynamicInsertRequest dynamicInsertRequest)
         {
             return _routeManager.DynamicInsertRouteAddressesAsync(dynamicInsertRequest);
+        }
+
+        /// <summary>
+        /// Gets the route-level custom data for the specified route.
+        /// Uses GET /api/v5.0/routes/{route_id} and extracts the route_custom_data field.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <param name="resultResponse">Failure response</param>
+        /// <returns>An array of dictionaries representing route custom data, or null if not set</returns>
+        public Dictionary<string, string>[] GetRouteCustomData(string routeId, out ResultResponse resultResponse)
+        {
+            return _routeManager.GetRouteCustomData(routeId, out resultResponse);
+        }
+
+        /// <summary>
+        /// Gets the route-level custom data for the specified route asynchronously.
+        /// Uses GET /api/v5.0/routes/{route_id} and extracts the route_custom_data field.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <returns>A Tuple containing route custom data or/and failure response</returns>
+        public Task<Tuple<Dictionary<string, string>[], ResultResponse>> GetRouteCustomDataAsync(string routeId)
+        {
+            return _routeManager.GetRouteCustomDataAsync(routeId);
+        }
+
+        /// <summary>
+        /// Updates route-level custom data for the specified route.
+        /// Uses PUT /api/v5.0/routes with route_custom_data in the request body.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <param name="customData">The custom data to set on the route</param>
+        /// <param name="resultResponse">Failure response</param>
+        /// <returns>The updated route object</returns>
+        public DataObjectRoute UpdateRouteCustomData(
+            string routeId,
+            Dictionary<string, string>[] customData,
+            out ResultResponse resultResponse)
+        {
+            return _routeManager.UpdateRouteCustomData(routeId, customData, out resultResponse);
+        }
+
+        /// <summary>
+        /// Updates route-level custom data for the specified route asynchronously.
+        /// Uses PUT /api/v5.0/routes with route_custom_data in the request body.
+        /// </summary>
+        /// <param name="routeId">The route ID (32-character hex string)</param>
+        /// <param name="customData">The custom data to set on the route</param>
+        /// <returns>A Tuple containing the updated route or/and failure response</returns>
+        public Task<Tuple<DataObjectRoute, ResultResponse, string>> UpdateRouteCustomDataAsync(
+            string routeId,
+            Dictionary<string, string>[] customData)
+        {
+            return _routeManager.UpdateRouteCustomDataAsync(routeId, customData);
         }
 
         #endregion

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/AddOnRoutesApi/AddOnRoutesApiTests.cs
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/AddOnRoutesApi/AddOnRoutesApiTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -537,6 +537,114 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
 
 
             Assert.That(result.GetType(), Is.EqualTo(typeof(StatusResponse)));
+        }
+
+        [Test]
+        public void UpdateRouteCustomDataTest()
+        {
+            var route4Me = new Route4MeManagerV5(CApiKey);
+
+            var routeId = _tdr.SD10Stops_route.RouteID;
+
+            var customData = new[]
+            {
+                new Dictionary<string, string>
+                {
+                    { "priority", "high" },
+                    { "region", "west" }
+                },
+                new Dictionary<string, string>
+                {
+                    { "notes", "Handle with care" }
+                }
+            };
+
+            var updatedRoute = route4Me.UpdateRouteCustomData(routeId, customData, out ResultResponse resultResponse);
+
+            Assert.NotNull(updatedRoute, "UpdateRouteCustomData returned null. " +
+                                         (resultResponse?.Messages != null
+                                             ? string.Join("; ", resultResponse.Messages)
+                                             : ""));
+            Assert.That(updatedRoute.GetType(), Is.EqualTo(typeof(DataObjectRoute)));
+        }
+
+        [Test]
+        public async Task UpdateRouteCustomDataAsyncTest()
+        {
+            var route4Me = new Route4MeManagerV5(CApiKey);
+
+            var routeId = _tdr.SD10Stops_route.RouteID;
+
+            var customData = new[]
+            {
+                new Dictionary<string, string>
+                {
+                    { "priority", "high" },
+                    { "region", "west" }
+                }
+            };
+
+            var result = await route4Me.UpdateRouteCustomDataAsync(routeId, customData);
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Item1, "UpdateRouteCustomDataAsync returned null route.");
+            Assert.That(result.Item1.GetType(), Is.EqualTo(typeof(DataObjectRoute)));
+        }
+
+        [Test]
+        public void GetRouteCustomDataTest()
+        {
+            var route4Me = new Route4MeManagerV5(CApiKey);
+
+            var routeId = _tdr.SD10Stops_route.RouteID;
+
+            // First, set custom data on the route
+            var customData = new[]
+            {
+                new Dictionary<string, string>
+                {
+                    { "priority", "high" },
+                    { "region", "west" }
+                }
+            };
+
+            route4Me.UpdateRouteCustomData(routeId, customData, out _);
+
+            // Now, retrieve the custom data
+            var retrievedCustomData = route4Me.GetRouteCustomData(routeId, out ResultResponse resultResponse);
+
+            Assert.NotNull(retrievedCustomData, "GetRouteCustomData returned null. " +
+                                                (resultResponse?.Messages != null
+                                                    ? string.Join("; ", resultResponse.Messages)
+                                                    : ""));
+            Assert.That(retrievedCustomData.Length, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task GetRouteCustomDataAsyncTest()
+        {
+            var route4Me = new Route4MeManagerV5(CApiKey);
+
+            var routeId = _tdr.SD10Stops_route.RouteID;
+
+            // First, set custom data on the route
+            var customData = new[]
+            {
+                new Dictionary<string, string>
+                {
+                    { "priority", "high" },
+                    { "region", "west" }
+                }
+            };
+
+            await route4Me.UpdateRouteCustomDataAsync(routeId, customData);
+
+            // Now, retrieve the custom data
+            var result = await route4Me.GetRouteCustomDataAsync(routeId);
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Item1, "GetRouteCustomDataAsync returned null custom data.");
+            Assert.That(result.Item1.Length, Is.GreaterThan(0));
         }
     }
 }


### PR DESCRIPTION
- Add RouteCustomData to DataObjectRoute, RouteFilterResponseData, RouteParametersQuery
- Add GetRouteCustomData / GetRouteCustomDataAsync
- Add UpdateRouteCustomData / UpdateRouteCustomDataAsync with parameter validation
- Add unit tests and CHANGELOG v8.12.0