### PR TITLE
fix(RA-347): unwrap API envelope in GetRoute and GetRoutes V5

### DIFF
--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Managers/RouteManagerV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Managers/RouteManagerV5.cs
@@ -30,11 +30,14 @@ namespace Route4MeSDKLibrary.Managers
         /// <summary>
         /// Retrieves a single route by ID with full details including addresses and parameters.
         /// Uses GET /api/v5.0/routes/{route_id} endpoint.
+        /// The API returns a <c>{ "data": { ... } }</c> envelope; this method unwraps it and
+        /// returns the route directly so that <c>route.Addresses</c> is accessible without
+        /// an extra <c>.Data</c> dereference.
         /// </summary>
         /// <param name="routeId">The route ID (32-character hex string)</param>
         /// <param name="resultResponse">Failure response</param>
-        /// <returns>The route response with data property containing route details</returns>
-        public GetRouteResponse GetRoute(string routeId, out ResultResponse resultResponse)
+        /// <returns>The route object including its Addresses array</returns>
+        public DataObjectRouteExtended GetRoute(string routeId, out ResultResponse resultResponse)
         {
             var genericParameters = new GenericParameters();
 
@@ -46,16 +49,19 @@ namespace Route4MeSDKLibrary.Managers
                 true,
                 out resultResponse);
 
-            return response;
+            return response?.Data;
         }
 
         /// <summary>
         /// Retrieves a single route by ID with full details including addresses and parameters asynchronously.
         /// Uses GET /api/v5.0/routes/{route_id} endpoint.
+        /// The API returns a <c>{ "data": { ... } }</c> envelope; this method unwraps it and
+        /// returns the route directly so that <c>route.Addresses</c> is accessible without
+        /// an extra <c>.Data</c> dereference.
         /// </summary>
         /// <param name="routeId">The route ID (32-character hex string)</param>
-        /// <returns>A Tuple type object containing the route response or/and failure response</returns>
-        public async Task<Tuple<GetRouteResponse, ResultResponse>> GetRouteAsync(string routeId)
+        /// <returns>A Tuple type object containing the route or/and failure response</returns>
+        public async Task<Tuple<DataObjectRouteExtended, ResultResponse>> GetRouteAsync(string routeId)
         {
             var genericParameters = new GenericParameters();
 
@@ -67,40 +73,44 @@ namespace Route4MeSDKLibrary.Managers
                 true,
                 false).ConfigureAwait(false);
 
-            return new Tuple<GetRouteResponse, ResultResponse>(result.Item1, result.Item2);
+            return new Tuple<DataObjectRouteExtended, ResultResponse>(result.Item1?.Data, result.Item2);
         }
 
         /// <summary>
         /// Retrieves a list of the routes.
+        /// The API returns a <c>{ "data": [...], "links": {...}, "meta": {...} }</c> envelope;
+        /// this method unwraps and returns only the <c>data</c> array.
         /// </summary>
         /// <param name="routeParameters">Query parameters</param>
         /// <param name="resultResponse">Failure response</param>
         /// <returns>An array of the routes</returns>
         public DataObjectRoute[] GetRoutes(RouteParametersQuery routeParameters, out ResultResponse resultResponse)
         {
-            var result = GetJsonObjectFromAPI<DataObjectRoute[]>(routeParameters,
+            var result = GetJsonObjectFromAPI<RoutesListResponse>(routeParameters,
                 R4MEInfrastructureSettingsV5.Routes,
                 HttpMethodType.Post,
                 false,
                 true,
                 out resultResponse);
 
-            return result;
+            return result?.Data;
         }
 
         /// <summary>
         /// Retrieves a list of the routes asynchronously.
+        /// The API returns a <c>{ "data": [...], "links": {...}, "meta": {...} }</c> envelope;
+        /// this method unwraps and returns only the <c>data</c> array.
         /// </summary>
         /// <param name="routeParameters">Query parameters <see cref="RouteParametersQuery"/></param>
         /// <returns>A Tuple type object containing a route list or/and failure response</returns>
         public async Task<Tuple<DataObjectRoute[], ResultResponse>> GetRoutesAsync(RouteParametersQuery routeParameters)
         {
-            var result = await GetJsonObjectFromAPIAsync<DataObjectRoute[]>(routeParameters,
+            var result = await GetJsonObjectFromAPIAsync<RoutesListResponse>(routeParameters,
                 R4MEInfrastructureSettingsV5.Routes,
                 HttpMethodType.Post,
                 null, true, false).ConfigureAwait(false);
 
-            return new Tuple<DataObjectRoute[], ResultResponse>(result.Item1, result.Item2);
+            return new Tuple<DataObjectRoute[], ResultResponse>(result.Item1?.Data, result.Item2);
         }
 
         /// <summary>
@@ -591,7 +601,7 @@ namespace Route4MeSDKLibrary.Managers
         {
             var response = GetRoute(routeId, out resultResponse);
 
-            return response?.Data?.RouteCustomData;
+            return response?.RouteCustomData;
         }
 
         /// <summary>
@@ -606,7 +616,7 @@ namespace Route4MeSDKLibrary.Managers
             var result = await GetRouteAsync(routeId).ConfigureAwait(false);
 
             return new Tuple<Dictionary<string, string>, ResultResponse>(
-                result.Item1?.Data?.RouteCustomData,
+                result.Item1?.RouteCustomData,
                 result.Item2);
         }
 

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeManagerV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/Route4MeManagerV5.cs
@@ -940,7 +940,7 @@ namespace Route4MeSDK
         /// <param name="routeId">The route ID (32-character hex string)</param>
         /// <param name="resultResponse">Failure response</param>
         /// <returns>The route with full details</returns>
-        public GetRouteResponse GetRoute(string routeId, out ResultResponse resultResponse)
+        public DataObjectRouteExtended GetRoute(string routeId, out ResultResponse resultResponse)
         {
             return _routeManager.GetRoute(routeId, out resultResponse);
         }
@@ -950,8 +950,8 @@ namespace Route4MeSDK
         /// Uses GET /api/v5.0/routes/{route_id} endpoint.
         /// </summary>
         /// <param name="routeId">The route ID (32-character hex string)</param>
-        /// <returns>A Tuple type object containing the route response or/and failure response</returns>
-        public Task<Tuple<GetRouteResponse, ResultResponse>> GetRouteAsync(string routeId)
+        /// <returns>A Tuple type object containing the route or/and failure response</returns>
+        public Task<Tuple<DataObjectRouteExtended, ResultResponse>> GetRouteAsync(string routeId)
         {
             return _routeManager.GetRouteAsync(routeId);
         }

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/API5/Routes/UpdateAndReadRouteCustomDataV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/API5/Routes/UpdateAndReadRouteCustomDataV5.cs
@@ -85,8 +85,7 @@ namespace Route4MeSDK.Examples
 
             // Step 4: GetRoute by id — route payload includes route-level custom_data
             Console.WriteLine("{0} Step 4: GetRoute by id (route-level custom_data in payload)...", tag);
-            var getRouteResponse = route4Me.GetRoute(routeId, out ResultResponse respGetRoute);
-            var routeById = getRouteResponse?.Data;
+            var routeById = route4Me.GetRoute(routeId, out ResultResponse respGetRoute);
             if (respGetRoute != null)
             {
                 PrintFailResponse(respGetRoute, tag);

--- a/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/AddOnRoutesApi/AddOnRoutesApiTests.cs
+++ b/route4me-csharp-sdk/Route4MeSdkV5UnitTest/V5/AddOnRoutesApi/AddOnRoutesApiTests.cs
@@ -97,15 +97,13 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
             var response = route4Me.GetRoute(routeId, out ResultResponse resultResponse);
 
             Assert.NotNull(response);
-            Assert.That(response.GetType(), Is.EqualTo(typeof(GetRouteResponse)));
-            Assert.NotNull(response.Data);
-            Assert.That(response.Data.GetType(), Is.EqualTo(typeof(DataObjectRouteExtended)));
-            Assert.That(response.Data.RouteID, Is.EqualTo(routeId));
+            Assert.That(response.GetType(), Is.EqualTo(typeof(DataObjectRouteExtended)));
+            Assert.That(response.RouteID, Is.EqualTo(routeId));
 
             // Verify extended fields are populated
-            Assert.NotNull(response.Data.Addresses, "Addresses should not be null");
-            Assert.True(response.Data.Addresses.Length > 0, "Addresses array should not be empty");
-            Assert.NotNull(response.Data.Parameters, "Parameters should not be null");
+            Assert.NotNull(response.Addresses, "Addresses should not be null");
+            Assert.True(response.Addresses.Length > 0, "Addresses array should not be empty");
+            Assert.NotNull(response.Parameters, "Parameters should not be null");
         }
 
         [Test]
@@ -121,15 +119,13 @@ namespace Route4MeSdkV5UnitTest.V5.AddOnRoutesApi
 
             Assert.NotNull(result);
             Assert.NotNull(result.Item1);
-            Assert.That(result.Item1.GetType(), Is.EqualTo(typeof(GetRouteResponse)));
-            Assert.NotNull(result.Item1.Data);
-            Assert.That(result.Item1.Data.GetType(), Is.EqualTo(typeof(DataObjectRouteExtended)));
-            Assert.That(result.Item1.Data.RouteID, Is.EqualTo(routeId));
+            Assert.That(result.Item1.GetType(), Is.EqualTo(typeof(DataObjectRouteExtended)));
+            Assert.That(result.Item1.RouteID, Is.EqualTo(routeId));
 
             // Verify extended fields are populated
-            Assert.NotNull(result.Item1.Data.Addresses, "Addresses should not be null");
-            Assert.True(result.Item1.Data.Addresses.Length > 0, "Addresses array should not be empty");
-            Assert.NotNull(result.Item1.Data.Parameters, "Parameters should not be null");
+            Assert.NotNull(result.Item1.Addresses, "Addresses should not be null");
+            Assert.True(result.Item1.Addresses.Length > 0, "Addresses array should not be empty");
+            Assert.NotNull(result.Item1.Parameters, "Parameters should not be null");
         }
 
         [Test]


### PR DESCRIPTION
Both endpoints return a { "data": ... } envelope that the SDK was not unwrapping, causing route.Addresses to be null on GetRoute and a single null-field item to be returned from GetRoutes.

- GetRoute/GetRouteAsync: deserialize as GetRouteResponse internally, return response.Data (DataObjectRouteExtended) directly so callers access route.Addresses without an extra .Data dereference
- GetRoutes/GetRoutesAsync: deserialize as RoutesListResponse (the { data, links, meta } envelope) and return result.Data array; POST method preserved to support complex body filters
- GetRouteCustomData/Async: updated to drop the now-removed .Data hop
- Route4MeManagerV5 facade: updated return type signatures to match
- UpdateAndReadRouteCustomDataV5 example: dropped redundant ?.Data
- AddOnRoutesApiTests: updated assertions to match flat return type