### PR TITLE
feat(v5): expose arrival time and stop sequence on route destinations

### DIFF
--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/RouteDestinations/AbstractRouteDestinationResource.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/RouteDestinations/AbstractRouteDestinationResource.cs
@@ -157,5 +157,15 @@ namespace Route4MeSDKLibrary.DataTypes.V5.RouteDestinations
         /// <summary>Notes attached to this destination.</summary>
         [DataMember(Name = "notes")]
         public List<RouteDestinationNote> Notes { get; set; }
+
+        /// <summary>
+        /// Actual arrival time as a Unix timestamp (UTC).
+        /// </summary>
+        [DataMember(Name = "actual_arrival_time_timestamp", EmitDefaultValue = false)]
+        public long? ActualArrivalTimeTimestamp { get; set; }
+
+        /// <summary>Zero-based stop sequence number within the route.</summary>
+        [DataMember(Name = "sequence_no", EmitDefaultValue = false)]
+        public int? SequenceNo { get; set; }
     }
 }

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/API5/RouteDestinations/GetRouteDestinationV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/API5/RouteDestinations/GetRouteDestinationV5.cs
@@ -70,6 +70,10 @@ namespace Route4MeSDK.Examples
                 Console.WriteLine("  status={0}", result.StopStatusId ?? "(none)");
                 Console.WriteLine("  customer_id={0}", result.CustomerId ?? "(none)");
                 Console.WriteLine("  is_visited={0}", result.IsVisited);
+                Console.WriteLine("  sequence_no={0}",
+                    result.SequenceNo.HasValue ? result.SequenceNo.Value.ToString() : "(null)");
+                Console.WriteLine("  actual_arrival_time_timestamp={0}",
+                    result.ActualArrivalTimeTimestamp.HasValue ? result.ActualArrivalTimeTimestamp.Value.ToString() : "(null)");
 
                 // Print destination-level custom key/value data
                 if (result.CustomFields == null || result.CustomFields.Count == 0)

--- a/route4me-csharp-sdk/Route4MeSDKTest/Examples/API5/RouteDestinations/GetRouteDestinationsListV5.cs
+++ b/route4me-csharp-sdk/Route4MeSDKTest/Examples/API5/RouteDestinations/GetRouteDestinationsListV5.cs
@@ -49,7 +49,7 @@ namespace Route4MeSDK.Examples
                 {
                     "route_destination_id", "destination_name", "address_stop_type", "stop_status_id",
                     "custom_fields", "is_depot", "is_visited", "is_departed",
-                    "notes", "sequence_no"
+                    "notes", "sequence_no", "actual_arrival_time_timestamp"
                 },
                 Page = 1,
                 PerPage = 50
@@ -68,6 +68,10 @@ namespace Route4MeSDK.Examples
                     {
                         Console.WriteLine("  destination_id={0}, stop_type={1}, status={2}",
                             item.RouteDestinationId, item.AddressStopType, item.StopStatusId ?? "(none)");
+                        Console.WriteLine("  sequence_no={0}",
+                            item.SequenceNo.HasValue ? item.SequenceNo.Value.ToString() : "(null)");
+                        Console.WriteLine("  actual_arrival_time_timestamp={0}",
+                            item.ActualArrivalTimeTimestamp.HasValue ? item.ActualArrivalTimeTimestamp.Value.ToString() : "(null)");
 
                         // Print destination-level custom key/value data
                         PrintDestinationCustomFields(item.CustomFields);


### PR DESCRIPTION
Surface additional V5 route destination fields in the SDK and print them in the examples.

Made-with: Cursor