### PR TITLE
fix(v5): correct route destination DTO types from API shape

### DIFF
--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/RouteDestinations/AbstractRouteDestinationResource.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/RouteDestinations/AbstractRouteDestinationResource.cs
@@ -118,9 +118,9 @@ namespace Route4MeSDKLibrary.DataTypes.V5.RouteDestinations
         [DataMember(Name = "stop_status_id")]
         public string StopStatusId { get; set; }
 
-        /// <summary>Workflow identifier associated with this stop.</summary>
+        /// <summary>Workflow identifier (hexadecimal UUID) associated with this stop.</summary>
         [DataMember(Name = "workflow_id")]
-        public int? WorkflowId { get; set; }
+        public string WorkflowId { get; set; }
 
         /// <summary>Stop type (e.g., "Dropoff", "Pickup", "Service").</summary>
         [DataMember(Name = "address_stop_type")]

--- a/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/RouteDestinations/FacilityDataResource.cs
+++ b/route4me-csharp-sdk/Route4MeSDKLibrary/DataTypes/V5/RouteDestinations/FacilityDataResource.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
+using Route4MeSDKLibrary.DataTypes.V5.Facilities;
+
 namespace Route4MeSDKLibrary.DataTypes.V5.RouteDestinations
 {
     /// <summary>
@@ -29,9 +31,9 @@ namespace Route4MeSDKLibrary.DataTypes.V5.RouteDestinations
     [DataContract]
     public class FacilityDataResource
     {
-        /// <summary>Unique integer identifier for the facility.</summary>
+        /// <summary>Facility identifier (32-character hexadecimal UUID).</summary>
         [DataMember(Name = "facility_id")]
-        public int? FacilityId { get; set; }
+        public string FacilityId { get; set; }
 
         /// <summary>Human-readable alias for the facility (e.g., "Main Warehouse").</summary>
         [DataMember(Name = "facility_alias")]
@@ -41,13 +43,13 @@ namespace Route4MeSDKLibrary.DataTypes.V5.RouteDestinations
         [DataMember(Name = "status")]
         public string Status { get; set; }
 
-        /// <summary>Short status code (e.g., "A").</summary>
+        /// <summary>Numeric status code (e.g., 1 for Active).</summary>
         [DataMember(Name = "status_code")]
-        public string StatusCode { get; set; }
+        public int? StatusCode { get; set; }
 
-        /// <summary>Coordinates of the facility formatted as "lat,lng" (e.g., "49.8397,24.0297").</summary>
+        /// <summary>Facility coordinates as a nested object with <c>lat</c> and <c>lng</c>.</summary>
         [DataMember(Name = "coordinates")]
-        public string Coordinates { get; set; }
+        public FacilityCoordinates Coordinates { get; set; }
 
         /// <summary>Street address of the facility.</summary>
         [DataMember(Name = "address")]


### PR DESCRIPTION
GET /route-destinations/{id} responses now deserialize cleanly. Several fields on the destination resource graph were misshapen:

- AbstractRouteDestinationResource.WorkflowId: int? -> string (32-char hex UUID; matches PodWorkflow.WorkflowId)
- FacilityDataResource.FacilityId: int? -> string (32-char hex UUID; matches FacilityResource.FacilityId)
- FacilityDataResource.Coordinates: string -> FacilityCoordinates (API returns a nested {lat, lng} object; reuses the existing FacilityCoordinates class already used by FacilityResource)
- FacilityDataResource.StatusCode: string -> int? (API returns an integer status code, e.g. 1)